### PR TITLE
Use strings for 'VisibilityTimeout'

### DIFF
--- a/SqsConsumer.php
+++ b/SqsConsumer.php
@@ -138,7 +138,7 @@ class SqsConsumer implements Consumer
                 '@region' => $this->queue->getRegion(),
                 'QueueUrl' => $this->context->getQueueUrl($this->queue),
                 'ReceiptHandle' => $message->getReceiptHandle(),
-                'VisibilityTimeout' => $message->getRequeueVisibilityTimeout(),
+                'VisibilityTimeout' => (string) $message->getRequeueVisibilityTimeout(),
             ]);
         } else {
             $this->context->getSqsClient()->deleteMessage([
@@ -165,7 +165,7 @@ class SqsConsumer implements Consumer
         ];
 
         if ($this->visibilityTimeout) {
-            $arguments['VisibilityTimeout'] = $this->visibilityTimeout;
+            $arguments['VisibilityTimeout'] = (string) $this->visibilityTimeout;
         }
 
         $result = $this->context->getSqsClient()->receiveMessage($arguments);

--- a/SqsDestination.php
+++ b/SqsDestination.php
@@ -150,7 +150,7 @@ class SqsDestination implements Topic, Queue
         if (null == $seconds) {
             unset($this->attributes['VisibilityTimeout']);
         } else {
-            $this->attributes['VisibilityTimeout'] = $seconds;
+            $this->attributes['VisibilityTimeout'] = (string) $seconds;
         }
     }
 

--- a/Tests/SqsConsumerTest.php
+++ b/Tests/SqsConsumerTest.php
@@ -208,7 +208,7 @@ class SqsConsumerTest extends TestCase
                 '@region' => 'theRegion',
                 'QueueUrl' => 'theQueueUrl',
                 'ReceiptHandle' => 'theReceipt',
-                'VisibilityTimeout' => 0,
+                'VisibilityTimeout' => '0',
             ]))
         ;
 
@@ -248,7 +248,7 @@ class SqsConsumerTest extends TestCase
                 '@region' => 'theRegion',
                 'QueueUrl' => 'theQueueUrl',
                 'ReceiptHandle' => 'theReceipt',
-                'VisibilityTimeout' => 30,
+                'VisibilityTimeout' => '30',
             ]))
         ;
 

--- a/Tests/SqsDestinationTest.php
+++ b/Tests/SqsDestinationTest.php
@@ -79,7 +79,7 @@ class SqsDestinationTest extends TestCase
         $destination = new SqsDestination('aDestinationName');
         $destination->setVisibilityTimeout(12345);
 
-        $this->assertSame(['VisibilityTimeout' => 12345], $destination->getAttributes());
+        $this->assertSame(['VisibilityTimeout' => '12345'], $destination->getAttributes());
     }
 
     public function testCouldSetFifoQueueAttributeAndUnsetIt()


### PR DESCRIPTION
The AWS API [expects a string](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html#API_SetQueueAttributes_RequestSyntax) for all attributes and will throw an error if an integer is provided:
> The provided type for `Attributes -> VisibilityTimeout` value was `integer`. The modeled type is `string`.

This PR converts ints to strings before setting them to the related attribute and updates tests to expect strings.